### PR TITLE
fix: improve ABot-M0 compatibility for RLinf distributed RL training

### DIFF
--- a/ABot/model/modules/action_model/flow_matching_head/cross_attention_dit.py
+++ b/ABot/model/modules/action_model/flow_matching_head/cross_attention_dit.py
@@ -31,12 +31,12 @@ from torch import nn
 class TimestepEncoder(nn.Module):
     def __init__(self, embedding_dim, compute_dtype=torch.float32):
         super().__init__()
+        self.compute_dtype = compute_dtype if compute_dtype is not None else torch.float32
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=1)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
 
     def forward(self, timesteps):
-        dtype = next(self.parameters()).dtype
-        timesteps_proj = self.time_proj(timesteps).to(dtype)
+        timesteps_proj = self.time_proj(timesteps).to(self.compute_dtype)
         timesteps_emb = self.timestep_embedder(timesteps_proj)  # (N, D)
         return timesteps_emb
 
@@ -271,6 +271,7 @@ class DiT(ModelMixin, ConfigMixin):
     ):
         # Encode timesteps
         temb = self.timestep_encoder(timestep)
+        temb = temb.to(hidden_states.dtype)
 
         # Process through transformer blocks - single pass through the blocks
         hidden_states = hidden_states.contiguous()

--- a/ABot/model/modules/vlm/QWen3.py
+++ b/ABot/model/modules/vlm/QWen3.py
@@ -124,6 +124,7 @@ class _QWen3_VL_Interface(nn.Module):
 
         # Extract state from kwargs if provided
         states = kwargs.get("state", None)
+        max_length = kwargs.get("max_length", None)
         
         # Create messages: one message per sample
         messages = []
@@ -169,13 +170,22 @@ class _QWen3_VL_Interface(nn.Module):
 
         # Preparation for inference
 
+        processor_kwargs = {
+            "tokenize": True,
+            "add_generation_prompt": True,
+            "return_dict": True,
+            "return_tensors": "pt",
+        }
+        if max_length is None:
+            processor_kwargs["padding"] = True
+        else:
+            processor_kwargs["padding"] = "max_length"
+            processor_kwargs["max_length"] = int(max_length)
+            processor_kwargs["truncation"] = True
+
         batch_inputs = self.processor.apply_chat_template(
-        messages,
-        tokenize=True,
-        padding=True,
-        add_generation_prompt=True,
-        return_dict=True,
-        return_tensors="pt"
+            messages,
+            **processor_kwargs,
         )
 
         # if solutions, mask out the solution tokens in labels


### PR DESCRIPTION
changes: 
- make timestep embedding dtype explicit and align it with hidden_states dtype to avoid mixed-precision/FSDP dtype mismatch issues
- update QWen3 input processing to support max_length-aware padding/truncation for stable batch shape behavior in distributed rollout/training